### PR TITLE
Set interrupted_by to null at the start of each round

### DIFF
--- a/back/src/game.js
+++ b/back/src/game.js
@@ -429,6 +429,7 @@ export class Game {
       this.current_round++;
       this.current_letter = this.random_letter();
 
+      this.current_round_interrupted_by = null;
       this.current_round_answers_final_received = [];
       this.current_round_votes_ready = [];
 


### PR DESCRIPTION
Set interrupted_by to null at the start of each round

**Behavior before**

- Round 1 : Timeout ends => Round ends => No message
- Round 2 : Player A ends => Round ends => "Player A ended the round"
- Round 3: Timeout ends => Round ends => "Player A ended the round"

**Behavior after**

- Round 1 : Timeout ends => Round ends => No message
- Round 2 : Player A ends => Round ends => "Player A ended the round"
- Round 3: Timeout ends => Round ends => No message