### PR TITLE
Replace "second" with "deuxième" in French.

### DIFF
--- a/front/locales/categories/fr.json
+++ b/front/locales/categories/fr.json
@@ -18,7 +18,7 @@
       "Mot",
       "Nom commun",
       "Verbe",
-      "Verbe du second groupe",
+      "Verbe du deuxième groupe",
       "Verbe du troisième groupe",
       "Verbe conjugué",
       "Verbe conjugué au subjonctif",

--- a/front/locales/fr.json
+++ b/front/locales/fr.json
@@ -91,7 +91,7 @@
   "The first player to finish interrupts all the others!": "Le premier joueur qui termine interrompt tous les autres !",
   "You must enter a word or phrase beginning with the letter {letter}.": "Vous devez entrer un mot ou une phrase commençant par la lettre {letter}.",
   "First round": "Premier tour",
-  "Second round": "Second tour",
+  "Second round": "Deuxième tour",
   "Third round": "Troisième tour",
   "Fourth round": "Quatrième tour",
   "Fifth round": "Cinquième tour",


### PR DESCRIPTION
According to academic French rules, the word
"second(e)" must be applied in contexts where
the enumeration does not go beyond two items.
That is, "second(e)" means "deuxième et dernier".
Ref: <https://www.academie-francaise.fr/second-deuxieme>