### PR TITLE
Fix ranking

### DIFF
--- a/back/src/game.js
+++ b/back/src/game.js
@@ -710,14 +710,13 @@ export class Game {
 
     this.final_scores.sort((a, b) => b.score - a.score);
 
-    let rank = 1;
-    this.final_scores.forEach((score, i) => {
-      // We only increase the rank if the score is different.
-      if (i > 0 && this.final_scores[i].score < this.final_scores[i - 1].score) {
-        rank++;
+    this.final_scores.forEach((_, i) => {
+      // Set same rank for equal scores and keep following ranks intact
+      if (i > 0 && this.final_scores[i].score == this.final_scores[i-1].score) {
+        this.final_scores[i].rank = this.final_scores[i-1].rank;
+      } else {
+        this.final_scores[i].rank = i + 1;
       }
-
-      this.final_scores[i].rank = rank;
     });
 
     this.broadcast("game-ended", {scores: this.final_scores});

--- a/back/src/game.js
+++ b/back/src/game.js
@@ -712,7 +712,7 @@ export class Game {
 
     this.final_scores.forEach((_, i) => {
       // Set same rank for equal scores and keep following ranks intact
-      if (i > 0 && this.final_scores[i].score == this.final_scores[i-1].score) {
+      if (i > 0 && this.final_scores[i].score === this.final_scores[i-1].score) {
         this.final_scores[i].rank = this.final_scores[i-1].rank;
       } else {
         this.final_scores[i].rank = i + 1;


### PR DESCRIPTION
Before this PR, players with the same score are ranked equally, and the following player would then have this rank plus one.

This PR implements ranking as seen usually in tournaments: players with the same score are ranked equally, and following players are then ranked using their position in the sorted list of scores.

Anyway, the code is a better description of what is happening. ^^

## QA

  * create a game,
  * have three players (at least) playing,
  * make the first two have the same score and the third one a lower score,
  * observe that the ranking is : 1st, 1st, 3rd (instead of 1st, 1st, 2nd before this PR).